### PR TITLE
Add support for illuminate/support v9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "illuminate/support": "^7.0|^8.0"
+        "illuminate/support": "^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "^5.0|^6.0",


### PR DESCRIPTION
- add support for illuminate/support:^9 to the composer.json to allow installations in apps running Laravel 9+